### PR TITLE
Added Website and Hostname observers

### DIFF
--- a/src/Observers/HostnameObserver.php
+++ b/src/Observers/HostnameObserver.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace Tenancy\HynNova\Observers;
+
+use Hyn\Tenancy\Contracts\Hostname;
+use Hyn\Tenancy\Events\Hostnames\Attached;
+use Hyn\Tenancy\Events\Hostnames\Created;
+use Hyn\Tenancy\Events\Hostnames\Creating;
+use Hyn\Tenancy\Events\Hostnames\Deleted;
+use Hyn\Tenancy\Events\Hostnames\Deleting;
+use Hyn\Tenancy\Events\Hostnames\Detached;
+use Hyn\Tenancy\Events\Hostnames\Updated;
+use Hyn\Tenancy\Events\Hostnames\Updating;
+use Hyn\Tenancy\Traits\DispatchesEvents;
+
+class HostnameObserver
+{
+	use DispatchesEvents;
+
+    /**
+     * Handle the hostname "creating" event.
+     *
+     * @param  Hostname  $hostname
+     * @return void
+     */
+    public function creating(Hostname $hostname)
+    {
+        $this->emitEvent(new Creating($hostname));
+    }
+
+    /**
+     * Handle the hostname "created" event.
+     *
+     * @param  Hostname  $hostname
+     * @return void
+     */
+    public function created(Hostname $hostname)
+    {
+        $this->emitEvent(new Created($hostname));
+    }
+
+    /**
+     * Handle the hostname "updating" event.
+     *
+     * @param  Hostname  $hostname
+     * @return void
+     */
+    public function updating(Hostname $hostname)
+    {
+        $this->emitEvent(new Updating($hostname));
+    }
+
+    /**
+     * Handle the hostname "updated" event.
+     *
+     * @param  Hostname  $hostname
+     * @return void
+     */
+    public function updated(Hostname $hostname)
+    {
+		$dirty = collect(array_keys($hostname->getDirty()))->mapWithKeys(function ($value, $key) use ($hostname) {
+			return [ $value => $hostname->getOriginal($value) ];
+		});
+
+		$this->emitEvent(new Updated($hostname, $dirty->toArray()));
+    }
+
+    /**
+     * Handle the hostname "deleting" event.
+     *
+     * @param  Hostname  $hostname
+     * @return void
+     */
+    public function deleting(Hostname $hostname)
+    {
+        $this->emitEvent(new Deleting($hostname));
+    }
+
+    /**
+     * Handle the hostname "deleted" event.
+     *
+     * @param  Hostname  $hostname
+     * @return void
+     */
+    public function deleted(Hostname $hostname)
+    {
+        $this->emitEvent(new Deleted($hostname));
+    }
+
+    /**
+     * Handle the hostname "saved" event.
+     *
+     * @param  Hostname  $hostname
+     * @return void
+     */
+    public function saved(Hostname $hostname)
+    {
+		if ($hostname->isDirty('website_id'))
+		{
+			if ($hostname->website_id)
+			{
+				$this->emitEvent(new Attached($hostname, $hostname->website));
+			}
+			else
+			{
+				$this->emitEvent(new Detached($hostname));
+			}
+		}
+    }
+
+    /**
+     * Handle the hostname "restored" event.
+     *
+     * @param  Hostname  $hostname
+     * @return void
+     */
+    public function restored(Hostname $hostname)
+    {
+        //
+    }
+
+    /**
+     * Handle the hostname "force deleted" event.
+     *
+     * @param  Hostname  $hostname
+     * @return void
+     */
+    public function forceDeleted(Hostname $hostname)
+    {
+        //
+    }
+}

--- a/src/Observers/WebsiteObserver.php
+++ b/src/Observers/WebsiteObserver.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Tenancy\HynNova\Observers;
+
+use Hyn\Tenancy\Contracts\Website;
+use Hyn\Tenancy\Events\Websites\Created;
+use Hyn\Tenancy\Events\Websites\Creating;
+use Hyn\Tenancy\Events\Websites\Deleted;
+use Hyn\Tenancy\Events\Websites\Deleting;
+use Hyn\Tenancy\Events\Websites\Updated;
+use Hyn\Tenancy\Events\Websites\Updating;
+use Hyn\Tenancy\Traits\DispatchesEvents;
+
+class WebsiteObserver
+{
+	use DispatchesEvents;
+
+	/**
+	 * Handle the models system website "creating" event.
+	 *
+	 * @param  Website  $website
+	 * @return void
+	 */
+	public function creating(Website $website)
+	{
+		$this->emitEvent(new Creating($website));
+	}
+
+    /**
+     * Handle the models system website "created" event.
+     *
+     * @param  Website  $website
+     * @return void
+     */
+    public function created(Website $website)
+    {
+		$this->emitEvent(new Created($website));
+    }
+
+    /**
+     * Handle the models system website "updating" event.
+     *
+     * @param  Website  $website
+     * @return void
+     */
+    public function updating(Website $website)
+    {
+        $this->emitEvent(new Updating($website));
+    }
+
+    /**
+     * Handle the models system website "updated" event.
+     *
+     * @param  Website  $website
+     * @return void
+     */
+    public function updated(Website $website)
+    {
+		$dirty = collect(array_keys($website->getDirty()))->mapWithKeys(function ($value, $key) use ($website) {
+			return [ $value => $website->getOriginal($value) ];
+		});
+
+		$this->emitEvent(new Updated($website, $dirty->toArray()));
+    }
+
+    /**
+     * Handle the models system website "deleting" event.
+     *
+     * @param  Website  $website
+     * @return void
+     */
+    public function deleting(Website $website)
+    {
+        $this->emitEvent(new Deleting($website));
+    }
+
+    /**
+     * Handle the models system website "deleted" event.
+     *
+     * @param  Website  $website
+     * @return void
+     */
+    public function deleted(Website $website)
+    {
+        $this->emitEvent(new Deleted($website));
+    }
+
+    /**
+     * Handle the models system website "restored" event.
+     *
+     * @param  Website  $website
+     * @return void
+     */
+    public function restored(Website $website)
+    {
+        //
+    }
+
+    /**
+     * Handle the models system website "force deleted" event.
+     *
+     * @param  Website  $website
+     * @return void
+     */
+    public function forceDeleted(Website $website)
+    {
+        //
+    }
+}

--- a/src/Resources/Hostname.php
+++ b/src/Resources/Hostname.php
@@ -21,7 +21,7 @@ class Hostname extends Resource
      *
      * @var string
      */
-    public static $title = 'name';
+    public static $title = 'fqdn';
 
     /**
      * The columns that should be searched.
@@ -66,6 +66,8 @@ class Hostname extends Resource
 
             Fields\DateTime::make('Under Maintenance Since')
                 ->rules(array_get($rules, 'under_maintenance_since', [])),
+
+            Fields\BelongsTo::make('Tenant', 'website'),
         ];
     }
 

--- a/src/Resources/Hostname.php
+++ b/src/Resources/Hostname.php
@@ -2,10 +2,10 @@
 
 namespace Tenancy\HynNova\Resources;
 
-use Hyn\Tenancy\Validators\HostnameValidator;
-use Laravel\Nova\Fields;
 use Illuminate\Http\Request;
+use Laravel\Nova\Fields;
 use Laravel\Nova\Resource;
+use Tenancy\HynNova\Validators\HostnameValidator;
 
 class Hostname extends Resource
 {
@@ -48,24 +48,26 @@ class Hostname extends Resource
      */
     public function fields(Request $request)
     {
-        $rules = (new HostnameValidator())->getRulesFor($this->model());
+        $creationRules = (new HostnameValidator())->getRulesFor($this->model());
+        $updateRules = (new HostnameValidator())->getRulesFor($this->model(), 'update');
 
         return [
             Fields\ID::make()->sortable(),
 
             Fields\Text::make('Fqdn')
                 ->sortable()
-                ->rules(array_get($rules, 'fqdn', [])),
+                ->creationRules(array_get($creationRules, 'fqdn', []))
+                ->updateRules(array_get($updateRules, 'fqdn', [])),
 
             Fields\Text::make('redirect_to')
                 ->sortable()
-                ->rules(array_get($rules, 'redirect_to', [])),
+                ->rules(array_get($creationRules, 'redirect_to', [])),
 
             Fields\Boolean::make('Force HTTPS')
-                ->rules(array_get($rules, 'force_https')),
+                ->rules(array_get($creationRules, 'force_https')),
 
             Fields\DateTime::make('Under Maintenance Since')
-                ->rules(array_get($rules, 'under_maintenance_since', [])),
+                ->rules(array_get($creationRules, 'under_maintenance_since', [])),
 
             Fields\BelongsTo::make('Tenant', 'website'),
         ];

--- a/src/Resources/Tenant.php
+++ b/src/Resources/Tenant.php
@@ -22,7 +22,7 @@ class Tenant extends Resource
      *
      * @var string
      */
-    public static $title = 'name';
+    public static $title = 'uuid';
 
     /**
      * The columns that should be searched.

--- a/src/Resources/Tenant.php
+++ b/src/Resources/Tenant.php
@@ -2,11 +2,10 @@
 
 namespace Tenancy\HynNova\Resources;
 
-use Hyn\Tenancy\Models\Website;
-use Hyn\Tenancy\Validators\WebsiteValidator;
-use Laravel\Nova\Fields;
 use Illuminate\Http\Request;
+use Laravel\Nova\Fields;
 use Laravel\Nova\Resource;
+use Tenancy\HynNova\Validators\WebsiteValidator;
 
 class Tenant extends Resource
 {
@@ -15,7 +14,7 @@ class Tenant extends Resource
      *
      * @var string
      */
-    public static $model = Website::class;
+    public static $model = \Hyn\Tenancy\Models\Website::class;
 
     /**
      * The single value that should be used to represent the resource when being displayed.
@@ -49,14 +48,16 @@ class Tenant extends Resource
      */
     public function fields(Request $request)
     {
-        $rules = (new WebsiteValidator())->getRulesFor($this->model());
+        $creationRules = (new WebsiteValidator())->getRulesFor($this->model());
+        $updateRules = (new WebsiteValidator())->getRulesFor($this->model(), 'update');
 
         return [
             Fields\ID::make()->sortable(),
 
             Fields\Text::make('Uuid')
                 ->sortable()
-                ->rules(array_get($rules, 'uuid', [])),
+                ->creationRules(array_get($creationRules, 'uuid', []))
+                ->updateRules(array_get($updateRules, 'uuid', [])),
 
             Fields\HasMany::make('Hostnames')
         ];

--- a/src/Resources/Tenant.php
+++ b/src/Resources/Tenant.php
@@ -57,7 +57,8 @@ class Tenant extends Resource
             Fields\Text::make('Uuid')
                 ->sortable()
                 ->creationRules(array_get($creationRules, 'uuid', []))
-                ->updateRules(array_get($updateRules, 'uuid', [])),
+                ->updateRules(array_get($updateRules, 'uuid', []))
+                ->help(!config('tenancy.website.disable-random-id') ? 'Will be generated automatically if left blank' : ''),
 
             Fields\HasMany::make('Hostnames')
         ];

--- a/src/ToolServiceProvider.php
+++ b/src/ToolServiceProvider.php
@@ -7,6 +7,8 @@ use Laravel\Nova\Events\ServingNova;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
 use Tenancy\HynNova\Http\Middleware\Authorize;
+use Tenancy\HynNova\Observers\HostnameObserver;
+use Tenancy\HynNova\Observers\WebsiteObserver;
 use Tenancy\HynNova\Resources\Hostname;
 use Tenancy\HynNova\Resources\Tenant;
 
@@ -21,9 +23,9 @@ class ToolServiceProvider extends ServiceProvider
     {
         $this->loadViewsFrom(__DIR__.'/../resources/views', 'hyn-nova');
 
-        $this->app->booted(function () {
-            $this->routes();
-        });
+//        $this->app->booted(function () {
+//            $this->routes();
+//        });
 
         Nova::serving(function (ServingNova $event) {
             Nova::resources([
@@ -31,6 +33,8 @@ class ToolServiceProvider extends ServiceProvider
                 Hostname::class
             ]);
         });
+
+        $this->bootObservers();
     }
 
     /**
@@ -57,5 +61,13 @@ class ToolServiceProvider extends ServiceProvider
     public function register()
     {
         //
+    }
+
+    public function bootObservers()
+    {
+        $config = $this->app['config']['tenancy.models'];
+
+        forward_static_call([$config['website'], 'observe'], WebsiteObserver::class);
+        forward_static_call([$config['hostname'], 'observe'], HostnameObserver::class);
     }
 }

--- a/src/Validators/HostnameValidator.php
+++ b/src/Validators/HostnameValidator.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Tenancy\HynNova\Validators;
+
+use Hyn\Tenancy\Abstracts\Validator;
+
+class HostnameValidator extends Validator
+{
+    protected $create = [
+        'fqdn' => ['required', 'string', 'unique:%system%.%hostnames%,fqdn'],
+        'redirect_to' => ['nullable', 'string', 'url'],
+        'force_https' => ['boolean'],
+        'under_maintenance_since' => ['nullable', 'date'],
+        'website_id' => ['nullable', 'integer', 'exists:%system%.%websites%,id'],
+    ];
+
+    protected $update = [
+        'id' => ['required', 'integer'],
+        'fqdn' => ['required', 'string', 'unique:%system%.%hostnames%,fqdn,{{resourceId}}'],
+        'redirect_to' => ['nullable', 'string', 'url'],
+        'force_https' => ['boolean'],
+        'under_maintenance_since' => ['nullable', 'date'],
+        'website_id' => ['nullable', 'integer', 'exists:%system%.%websites%,id'],
+    ];
+}

--- a/src/Validators/WebsiteValidator.php
+++ b/src/Validators/WebsiteValidator.php
@@ -12,4 +12,21 @@ class WebsiteValidator extends Validator
     protected $update = [
         'uuid' => ['required', 'string', "unique:%system%.%websites%,uuid,{{resourceId}}"],
     ];
+
+    /**
+     * @param $model
+     * @param string $for
+     * @return array
+     */
+    public function getRulesFor($model, $for = 'create'): array
+    {
+        $rules = $this->{$for} ?? [];
+
+        if (!config('tenancy.website.disable-random-id')) {
+            $key = array_search('required', $rules['uuid']);
+            $rules['uuid'][$key] = 'nullable';
+        }
+
+        return $this->replaceVariables($rules, $model);
+    }
 }

--- a/src/Validators/WebsiteValidator.php
+++ b/src/Validators/WebsiteValidator.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Tenancy\HynNova\Validators;
+
+use Hyn\Tenancy\Abstracts\Validator;
+
+class WebsiteValidator extends Validator
+{
+    protected $create = [
+        'uuid' => ['required', 'string', "unique:%system%.%websites%,uuid"],
+    ];
+    protected $update = [
+        'uuid' => ['required', 'string', "unique:%system%.%websites%,uuid,{{resourceId}}"],
+    ];
+}


### PR DESCRIPTION
Added both Website and Hostname observers to fire required events.
Wasn't able to test all events, but basic functionality of creating tenants works.
Also, I commented out `routes()` call from the provider as there are no routes file currently and it breaks upon package discovery.

**Known issues:**
Update validation doesn't work as it doesn't pass unique rule. Currently it uses creation rules for both create and update from `hyn/multi-tenant`:
```PHP
$rules = (new WebsiteValidator())->getRulesFor($this->model());

Fields\Text::make('Uuid')
    ->sortable()
    ->rules(array_get($rules, 'uuid', [])),
```
Nova let's you specify custom rules for creation and update, so the field would look something like:
```PHP
Fields\Text::make('Uuid')
    ->sortable()
    ->rules('required', 'string')
    ->creationRules('unique:system.websites,uuid')
    ->updateRules('unique:system.websites,uuid,{{resourceId}}'),
```

**Note:** this would require to keep validation rules in this package as nova requires you to use `{{resourceId}}` placeholder.  I tested by getting update rules from `WebsiteValidator`, but it doesn't see current model.
```PHP
// Does not work
$rules = (new WebsiteValidator())->getRulesFor($this->model(), 'update');
```